### PR TITLE
Fix grid rendering in scene

### DIFF
--- a/ProEngine/Core/Scene/SceneRenderer.cpp
+++ b/ProEngine/Core/Scene/SceneRenderer.cpp
@@ -22,7 +22,11 @@ void SceneRenderer::RenderScene(Scene* scene)
         }
         else if (renderer.mesh_ptr)
         {
-            Renderer3D::DrawMesh(worldTransform, renderer.mesh_ptr, renderer.color, entityID);
+            auto material = renderer.mesh_ptr->GetMaterial();
+            if (material)
+                Renderer3D::DrawMesh(worldTransform, renderer.mesh_ptr, material, entityID);
+            else
+                Renderer3D::DrawMesh(worldTransform, renderer.mesh_ptr, renderer.color, entityID);
         }
         else
         {


### PR DESCRIPTION
## Summary
- allow SceneRenderer to use mesh materials when drawing entities

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68534f119560833280de85944c3a6e78