### PR TITLE
Implement shader-based viewport grid

### DIFF
--- a/ProEngine/Assets/Shaders/Renderer3D_Mesh.glsl
+++ b/ProEngine/Assets/Shaders/Renderer3D_Mesh.glsl
@@ -89,12 +89,26 @@ uniform sampler2D u_AlbedoMap;
 uniform sampler2D u_NormalMap;
 uniform sampler2D u_MetallicMap;
 uniform sampler2D u_RoughnessMap;
+uniform int u_UseGrid;
+
+vec4 GridColor(vec2 uv)
+{
+    float thickness = 0.02;
+    vec2 grid = abs(fract(uv - 0.5) - 0.5);
+    float line = step(grid.x, thickness) + step(grid.y, thickness);
+    line = clamp(line, 0.0, 1.0);
+    vec3 bg = vec3(0.2);
+    vec3 color = mix(bg, u_MaterialAlbedoColor.rgb, line);
+    return vec4(color, 1.0);
+}
 
 void main()
 {
     // Sample material properties
     vec4 albedoSample = texture(u_AlbedoMap, v_TexCoord * u_MaterialTilingFactor);
     vec4 finalAlbedo = albedoSample * u_MaterialAlbedoColor;
+    if(u_UseGrid == 1)
+        finalAlbedo = GridColor(v_TexCoord * u_MaterialTilingFactor);
 
     // Normalize the normal
     vec3 normal = normalize(v_Normal);

--- a/ProEngine/Core/Editor/Frame/Viewport/Viewport.cpp
+++ b/ProEngine/Core/Editor/Frame/Viewport/Viewport.cpp
@@ -1,6 +1,7 @@
 #include "Viewport.h"
 #include "Core/Renderer/Renderer3D.h"
 #include "Core/Scene/EntityHandle.h"
+#include "Core/Renderer/Material.h"
 #include <glad/glad.h>
 
 namespace ProEngine
@@ -274,7 +275,7 @@ namespace ProEngine
         plane_entity_ = scene->CreateEntity("plane");
 
         Ref<Material> mat = CreateRef<Material>();
-        mat->SetAlbedoMap(Texture2D::Create("../ProEngine/Assets/Editor/Textures/grid_2x2.png"));
+        mat->SetUseGrid(true);
         mat->SetTilingFactor(glm::vec2(1000.0f, 1000.0f));
 
         RendererComponent rc;

--- a/ProEngine/Core/Renderer/Material.h
+++ b/ProEngine/Core/Renderer/Material.h
@@ -36,7 +36,10 @@ namespace ProEngine {
         inline float GetRoughness() const { return m_Roughness; }
 
         inline void SetTilingFactor(const glm::vec2& factor) { m_TilingFactor = factor; }
-        inline const glm::vec2& GetTilingFactor() const { return m_TilingFactor; }
+    inline const glm::vec2& GetTilingFactor() const { return m_TilingFactor; }
+
+        inline void SetUseGrid(bool useGrid) { m_UseGrid = useGrid; }
+        inline bool GetUseGrid() const { return m_UseGrid; }
 
     private:
         glm::vec4 m_AlbedoColor = { 1.0f, 1.0f, 1.0f, 1.0f };
@@ -49,6 +52,7 @@ namespace ProEngine {
         float m_Metallic = 0.0f;
         float m_Roughness = 0.5f;
         glm::vec2 m_TilingFactor = {1.0f, 1.0f};
+        bool m_UseGrid = false;
     };
 
 }  // namespace ProEngine

--- a/ProEngine/Core/Renderer/Renderer3D.cpp
+++ b/ProEngine/Core/Renderer/Renderer3D.cpp
@@ -240,6 +240,7 @@ namespace ProEngine
                                         material->GetRoughness());
             s_Data.MeshShader->SetFloat2("u_MaterialTilingFactor",
                                         material->GetTilingFactor());
+            s_Data.MeshShader->SetInt("u_UseGrid", material->GetUseGrid() ? 1 : 0);
             s_Data.MeshShader->SetInt("u_AlbedoMap", 0);
             s_Data.MeshShader->SetInt("u_NormalMap", 1);
             s_Data.MeshShader->SetInt("u_MetallicMap", 2);


### PR DESCRIPTION
## Summary
- add `UseGrid` flag to Material to allow grid shader
- modify Renderer3D mesh shader to draw grid procedurally
- update renderer to pass grid flag to shader
- switch viewport grid plane to shader-based grid

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854042edee4833296831761dbf163be