### PR TITLE
Introduce Filament framebuffer option

### DIFF
--- a/ProEngine/CMakeLists.txt
+++ b/ProEngine/CMakeLists.txt
@@ -398,6 +398,8 @@ engine_add_library(PEPlatform
         Platform/OpenGL/OpenGLRendererAPI.cpp
         Platform/OpenGL/OpenGLFramebuffer.h
         Platform/OpenGL/OpenGLFramebuffer.cpp
+        Platform/Filament/FilamentFramebuffer.h
+        Platform/Filament/FilamentFramebuffer.cpp
         Platform/OpenGL/OpenGLShader.h
         Platform/OpenGL/OpenGLShader.cpp
         Platform/OpenGL/OpenGLBuffer.h

--- a/ProEngine/Config.h
+++ b/ProEngine/Config.h
@@ -22,6 +22,9 @@
 // to debug the layers
 // #define PROENGINE_DEBUG_LAYERS
 
+// use Filament to render into framebuffers
+// #define PROENGINE_USE_FILAMENT_FRAMEBUFFER
+
 #ifdef DEBUG
 #if defined(PROENGINE_PLATFORM_WINDOWS)
     #define PENGINE_DEBUGBREAK() __debugbreak()

--- a/ProEngine/Core/Editor/Frame/Viewport/Viewport.cpp
+++ b/ProEngine/Core/Editor/Frame/Viewport/Viewport.cpp
@@ -23,11 +23,18 @@ namespace ProEngine
         spec.Width = Application::Get().GetWindow().GetWidth();
         spec.Height = Application::Get().GetWindow().GetHeight();
         spec.EnableEntityIDAttachment = true;
+#ifdef PROENGINE_USE_FILAMENT_FRAMEBUFFER
+        spec.UseFilament = true;
+#endif
         framebuffer_ = Framebuffer::Create(spec);
         window_size_ = {(float)spec.Width, (float)spec.Height};
+#ifndef PROENGINE_USE_FILAMENT_FRAMEBUFFER
         camera_controller_.OnResize(spec.Width, spec.Height);
+#endif
 
+#ifndef PROENGINE_USE_FILAMENT_FRAMEBUFFER
         InitializeGrid();
+#endif
     }
 
     void Viewport::OnDetach()
@@ -38,6 +45,10 @@ namespace ProEngine
     void Viewport::OnUpdate(Timestep ts)
     {
         Layer::OnUpdate(ts);
+#ifdef PROENGINE_USE_FILAMENT_FRAMEBUFFER
+        framebuffer_->Bind(); // FilamentFramebuffer renders internally
+        framebuffer_->Unbind();
+#else
         camera_controller_.OnUpdate(ts);
         time_ += ts;
         RenderCommand::SetClearColor({0.1f, 0.2f, 0.2f, 1.0f});
@@ -53,6 +64,7 @@ namespace ProEngine
         Application::Get().GetActiveScene()->OnUpdate(ts);
         Renderer3D::EndScene();
         framebuffer_->Unbind();
+#endif
     }
 
     void Viewport::OnImGuiRender()
@@ -64,7 +76,9 @@ namespace ProEngine
             if (size.x > 0 && size.y > 0 && (size.x != window_size_.x || size.y != window_size_.y))
             {
                 framebuffer_->Resize((uint32_t)size.x, (uint32_t)size.y);
+#ifndef PROENGINE_USE_FILAMENT_FRAMEBUFFER
                 camera_controller_.OnResize(size.x, size.y);
+#endif
                 window_size_ = {size.x, size.y};
             }
             ImGui::Image((void*)(intptr_t)framebuffer_->GetColorAttachmentRendererID(), size, ImVec2{0, 1}, ImVec2{1, 0});
@@ -73,6 +87,7 @@ namespace ProEngine
             ImVec2 cursor_pos = ImGui::GetItemRectMin();
             ImVec2 panel_size = size;
 
+#ifndef PROENGINE_USE_FILAMENT_FRAMEBUFFER
             if (ImGui::IsWindowHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
             {
                 ImVec2 mousePos = ImGui::GetMousePos();
@@ -103,6 +118,7 @@ namespace ProEngine
                     }
                 }
             }
+#endif
 
             viewport_location_ = ImGui::GetWindowPos();
             viewport_size_ = ImGui::GetWindowSize();
@@ -159,10 +175,12 @@ namespace ProEngine
     void Viewport::OnEvent(Event& event)
     {
         Layer::OnEvent(event);
+#ifndef PROENGINE_USE_FILAMENT_FRAMEBUFFER
         if (camera_movement_enabled_)
         {
             camera_controller_.OnEvent(event);
         }
+#endif
 
         EventDispatcher dispatcher(event);
         dispatcher.Dispatch<KeyPressedEvent>(PENGINE_BIND_EVENT_FN(OnKeyPressed));

--- a/ProEngine/Core/Renderer/Framebuffer.cpp
+++ b/ProEngine/Core/Renderer/Framebuffer.cpp
@@ -1,11 +1,23 @@
 #include "Core/Renderer/Framebuffer.h"
 #include "Core/Renderer/RendererAPI.h"
 #include "Platform/OpenGL/OpenGLFramebuffer.h"
+#ifdef PROENGINE_USE_FILAMENT_FRAMEBUFFER
+#include "Platform/Filament/FilamentFramebuffer.h"
+#endif
 
 namespace ProEngine {
 
 Ref<Framebuffer> Framebuffer::Create(const FramebufferSpecification& spec)
 {
+    if (spec.UseFilament)
+    {
+#ifdef PROENGINE_USE_FILAMENT_FRAMEBUFFER
+        return CreateRef<FilamentFramebuffer>(spec);
+#else
+        PENGINE_CORE_WARN("Filament framebuffer requested but support not enabled");
+#endif
+    }
+
     switch (RendererAPI::GetAPI())
     {
     case RendererAPI::API::OpenGL:

--- a/ProEngine/Core/Renderer/Framebuffer.h
+++ b/ProEngine/Core/Renderer/Framebuffer.h
@@ -8,6 +8,7 @@ namespace ProEngine {
     {
         uint32_t Width = 0, Height = 0;
         bool EnableEntityIDAttachment = false;
+        bool UseFilament = false; // When true create a Filament based framebuffer
     };
 
     class Framebuffer

--- a/ProEngine/Platform/Filament/FilamentFramebuffer.cpp
+++ b/ProEngine/Platform/Filament/FilamentFramebuffer.cpp
@@ -1,0 +1,208 @@
+#include "Platform/Filament/FilamentFramebuffer.h"
+#include "PEPCH.h"
+#include <glad/glad.h>
+#include <utils/EntityManager.h>
+#include <gltfio/AssetLoader.h>
+#include <gltfio/ResourceLoader.h>
+#include <gltfio/MaterialProvider.h>
+#include <gltfio/FilamentAsset.h>
+#include <gltfio/TextureProvider.h>
+#include <algorithm>
+#include <fstream>
+#include <vector>
+
+namespace ProEngine {
+
+FilamentFramebuffer::FilamentFramebuffer(const FramebufferSpecification& spec) {
+    specification_ = spec;
+    CreateResources();
+}
+
+FilamentFramebuffer::~FilamentFramebuffer() {
+    DestroyResources();
+}
+
+void FilamentFramebuffer::CreateResources() {
+    render_width_ = specification_.Width;
+    render_height_ = specification_.Height;
+
+    engine_ = filament::Engine::Builder()
+                  .backend(filament::Engine::Backend::OPENGL)
+                  .build();
+    renderer_ = engine_->createRenderer();
+    swap_chain_ = engine_->createSwapChain(1, 1);
+
+    color_texture_ = filament::Texture::Builder()
+                         .width(render_width_)
+                         .height(render_height_)
+                         .levels(1)
+                         .usage(filament::Texture::Usage::COLOR_ATTACHMENT |
+                                filament::Texture::Usage::SAMPLEABLE)
+                         .format(filament::Texture::InternalFormat::RGBA8)
+                         .build(*engine_);
+
+    depth_texture_ = filament::Texture::Builder()
+                         .width(render_width_)
+                         .height(render_height_)
+                         .levels(1)
+                         .usage(filament::Texture::Usage::DEPTH_ATTACHMENT)
+                         .format(filament::Texture::InternalFormat::DEPTH24)
+                         .build(*engine_);
+
+    render_target_ = filament::RenderTarget::Builder()
+                         .texture(filament::RenderTarget::AttachmentPoint::COLOR,
+                                  color_texture_)
+                         .texture(filament::RenderTarget::AttachmentPoint::DEPTH,
+                                  depth_texture_)
+                         .build(*engine_);
+
+    scene_ = engine_->createScene();
+    view_ = engine_->createView();
+
+    camera_entity_ = utils::EntityManager::get().create();
+    camera_ = engine_->createCamera(camera_entity_);
+    camera_->setProjection(45.0f,
+                           render_width_ / static_cast<float>(render_height_),
+                           0.1f, 1000.0f);
+    camera_->lookAt({0, 0, 5}, {0, 0, 0});
+
+    view_->setScene(scene_);
+    view_->setCamera(camera_);
+    filament::Viewport vp{0, 0, (uint32_t)render_width_, (uint32_t)render_height_};
+    view_->setViewport(vp);
+    view_->setRenderTarget(render_target_);
+    view_->setPostProcessingEnabled(false);
+
+    pixel_buffer_ = new uint8_t[render_width_ * render_height_ * 4];
+
+    glGenTextures(1, &opengl_texture_id_);
+    glBindTexture(GL_TEXTURE_2D, opengl_texture_id_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, render_width_, render_height_, 0,
+                 GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glGenFramebuffers(1, &framebuffer_gl_id_);
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_gl_id_);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           opengl_texture_id_, 0);
+
+    glGenRenderbuffers(1, &depth_buffer_id_);
+    glBindRenderbuffer(GL_RENDERBUFFER, depth_buffer_id_);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, render_width_,
+                          render_height_);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER,
+                              depth_buffer_id_);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    LoadModel();
+    SetupLighting();
+}
+
+void FilamentFramebuffer::DestroyResources() {
+    if (engine_) {
+        if (render_target_) engine_->destroy(render_target_);
+        if (color_texture_) engine_->destroy(color_texture_);
+        if (depth_texture_) engine_->destroy(depth_texture_);
+        if (view_) engine_->destroy(view_);
+        if (scene_) engine_->destroy(scene_);
+        if (renderer_) engine_->destroy(renderer_);
+        if (swap_chain_) engine_->destroy(swap_chain_);
+        engine_->destroyCameraComponent(camera_entity_);
+        filament::Engine::destroy(&engine_);
+    }
+
+    if (opengl_texture_id_) glDeleteTextures(1, &opengl_texture_id_);
+    if (framebuffer_gl_id_) glDeleteFramebuffers(1, &framebuffer_gl_id_);
+    if (depth_buffer_id_) glDeleteRenderbuffers(1, &depth_buffer_id_);
+    delete[] pixel_buffer_;
+}
+
+void FilamentFramebuffer::CopyFilamentToOpenGL() const {
+    filament::backend::PixelBufferDescriptor buffer(
+        pixel_buffer_,
+        render_width_ * render_height_ * 4,
+        filament::backend::PixelDataFormat::RGBA,
+        filament::backend::PixelDataType::UBYTE);
+
+    renderer_->readPixels(render_target_, 0, 0, render_width_, render_height_,
+                          std::move(buffer));
+    engine_->flushAndWait();
+
+    glBindTexture(GL_TEXTURE_2D, opengl_texture_id_);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, render_width_, render_height_,
+                    GL_RGBA, GL_UNSIGNED_BYTE, pixel_buffer_);
+    glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+void FilamentFramebuffer::Bind() const {
+    if (renderer_->beginFrame(swap_chain_)) {
+        renderer_->render(view_);
+        renderer_->endFrame();
+    }
+    CopyFilamentToOpenGL();
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_gl_id_);
+}
+
+void FilamentFramebuffer::Unbind() const {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void FilamentFramebuffer::Resize(uint32_t width, uint32_t height) {
+    // simple implementation: recreate everything
+    specification_.Width = width;
+    specification_.Height = height;
+    DestroyResources();
+    CreateResources();
+}
+
+void FilamentFramebuffer::LoadModel() {
+    auto* matProvider = filament::gltfio::createJitShaderProvider(engine_);
+    asset_loader_ = filament::gltfio::AssetLoader::create({engine_, matProvider});
+    resource_loader_ = new filament::gltfio::ResourceLoader({engine_, "../ProEngine/Assets/Models", true});
+    auto stb_decoder = filament::gltfio::createStbProvider(engine_);
+    resource_loader_->addTextureProvider("image/png", stb_decoder);
+    resource_loader_->addTextureProvider("image/jpeg", stb_decoder);
+
+    const char* path = "../ProEngine/Assets/Models/DragonAttenuation.glb";
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) return;
+    auto size = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::vector<uint8_t> buffer(size);
+    file.read(reinterpret_cast<char*>(buffer.data()), size);
+    file.close();
+
+    asset_ = asset_loader_->createAsset(buffer.data(), (uint32_t)buffer.size());
+    if (!asset_) return;
+    resource_loader_->loadResources(asset_);
+    asset_->releaseSourceData();
+    scene_->addEntities(asset_->getEntities(), asset_->getEntityCount());
+
+    auto aabb = asset_->getBoundingBox();
+    glm::vec3 max = {aabb.max.x, aabb.max.y, aabb.max.z};
+    glm::vec3 min = {aabb.min.x, aabb.min.y, aabb.min.z};
+    model_center_ = (max + min) * 0.5f;
+    float sizeMax = std::max({max.x - min.x, max.y - min.y, max.z - min.z});
+    float distance = sizeMax * 3.0f;
+    camera_->lookAt({model_center_.x, model_center_.y, model_center_.z + distance},
+                    {model_center_.x, model_center_.y, model_center_.z},
+                    {0,1,0});
+}
+
+void FilamentFramebuffer::SetupLighting() {
+    auto light = utils::EntityManager::get().create();
+    filament::LightManager::Builder(filament::LightManager::Type::SUN)
+        .color({1.0f,1.0f,1.0f})
+        .intensity(50000.0f)
+        .direction({0,-1,0})
+        .castShadows(false)
+        .build(*engine_, light);
+    scene_->addEntity(light);
+}
+
+} // namespace ProEngine

--- a/ProEngine/Platform/Filament/FilamentFramebuffer.h
+++ b/ProEngine/Platform/Filament/FilamentFramebuffer.h
@@ -1,0 +1,70 @@
+#pragma once
+#include "Core/Renderer/Framebuffer.h"
+
+#include <filament/Engine.h>
+#include <filament/Renderer.h>
+#include <filament/Scene.h>
+#include <filament/SwapChain.h>
+#include <filament/View.h>
+#include <filament/Camera.h>
+#include <filament/RenderTarget.h>
+#include <filament/Texture.h>
+#include <utils/Entity.h>
+#include <glm.hpp>
+#include <backend/PixelBufferDescriptor.h>
+
+namespace ProEngine {
+
+class FilamentFramebuffer : public Framebuffer {
+public:
+    explicit FilamentFramebuffer(const FramebufferSpecification& spec);
+    ~FilamentFramebuffer() override;
+
+    void Bind() const override;
+    void Unbind() const override;
+    void Resize(uint32_t width, uint32_t height) override;
+
+    uint32_t GetColorAttachmentRendererID() const override { return opengl_texture_id_; }
+    uint32_t GetEntityIDAttachmentRendererID() const override { return 0; }
+    uint32_t GetDepthAttachmentRendererID() const override { return depth_buffer_id_; }
+    uint32_t GetRendererID() const override { return framebuffer_gl_id_; }
+
+    filament::Engine* GetEngine() const { return engine_; }
+    filament::Scene* GetScene() const { return scene_; }
+    filament::View* GetView() const { return view_; }
+    filament::Camera* GetCamera() const { return camera_; }
+
+private:
+    void CreateResources();
+    void DestroyResources();
+    void CopyFilamentToOpenGL() const;
+    void LoadModel();
+    void SetupLighting();
+
+    mutable filament::Engine* engine_ = nullptr;
+    filament::Renderer* renderer_ = nullptr;
+    filament::SwapChain* swap_chain_ = nullptr;
+    filament::Scene* scene_ = nullptr;
+    filament::View* view_ = nullptr;
+    filament::Camera* camera_ = nullptr;
+    filament::RenderTarget* render_target_ = nullptr;
+    filament::Texture* color_texture_ = nullptr;
+    filament::Texture* depth_texture_ = nullptr;
+    filament::gltfio::AssetLoader* asset_loader_ = nullptr;
+    filament::gltfio::ResourceLoader* resource_loader_ = nullptr;
+    filament::gltfio::FilamentAsset* asset_ = nullptr;
+
+    int render_width_ = 0;
+    int render_height_ = 0;
+
+    mutable uint8_t* pixel_buffer_ = nullptr;
+
+    GLuint opengl_texture_id_ = 0;
+    GLuint framebuffer_gl_id_ = 0;
+    GLuint depth_buffer_id_ = 0;
+    utils::Entity camera_entity_;
+
+    glm::vec3 model_center_{0.0f};
+};
+
+} // namespace ProEngine


### PR DESCRIPTION
## Summary
- add `UseFilament` flag to framebuffer specification
- implement `FilamentFramebuffer` using Filament render target
- integrate Filament framebuffer support in creation logic
- allow viewport to use Filament for rendering when enabled
- expose new build option `PROENGINE_USE_FILAMENT_FRAMEBUFFER`

## Testing
- `./build.sh` *(fails: 'Cocoa/Cocoa.h' not found and 'filament/Engine.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b3ee4ce4832984bb757b59b07587